### PR TITLE
Renamed the keyboard event handler 'all' to 'default' ...

### DIFF
--- a/src/components/KeyboardControlsProvider/KeyboardControlsProvider.js
+++ b/src/components/KeyboardControlsProvider/KeyboardControlsProvider.js
@@ -36,7 +36,6 @@ const KeyboardControlsProvider = props => (
     )}
     onKeyEvent={(key, ev) => {
       const keyCombo = getKeyCombinationPressed(key, ev);
-      console.log(props.commands[keyCombo], props.commands.default);
       (props.commands[keyCombo] || props.commands.default || emptyFn)(
         keyCombo,
         key,

--- a/src/components/KeyboardControlsProvider/KeyboardControlsProvider.js
+++ b/src/components/KeyboardControlsProvider/KeyboardControlsProvider.js
@@ -31,10 +31,13 @@ const getKeyCombinationPressed = (key, ev) => {
 
 const KeyboardControlsProvider = props => (
   <KeyboardEventHandler
-    handleKeys={Object.keys(props.commands)}
+    handleKeys={Object.keys(props.commands).map(
+      key => (key === 'default' ? 'all' : key)
+    )}
     onKeyEvent={(key, ev) => {
       const keyCombo = getKeyCombinationPressed(key, ev);
-      (props.commands[keyCombo] || props.commands.all || emptyFn)(
+      console.log(props.commands[keyCombo], props.commands.default);
+      (props.commands[keyCombo] || props.commands.default || emptyFn)(
         keyCombo,
         key,
         ev

--- a/src/components/KeyboardControlsProvider/KeyboardControlsProvider.mdx
+++ b/src/components/KeyboardControlsProvider/KeyboardControlsProvider.mdx
@@ -17,7 +17,12 @@ Handles the keyboard events
   {({ setState, state }) => {
     return (
       <div>
-        <KeyboardControlsProvider commands={{'all': (keyCombo, key, ev) => setState({lastKey: keyCombo})}} />
+        <KeyboardControlsProvider
+          commands={{
+            'default': (keyCombo, key, ev) => setState({lastKey: keyCombo}),
+            'alt+a': () => setState({lastKey: 'special alt a handler'}),
+          }}
+        />
         <p>Last key pressed:<b>{state.lastKey}</b></p>
       </div>
     );


### PR DESCRIPTION
... this way it is clear that the `default` is a fallback.