### PR TITLE
Allows for url to drive resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "immutability-helper": "^2.8.1",
     "langs": "^2.0.0",
     "prop-types": "^15.6.2",
+    "query-string": "^6.2.0",
     "react": "^16.4.2",
     "react-color": "^2.14.1",
     "react-dom": "^16.4.2",

--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -39,9 +39,10 @@ export const resetDocument = () => ({
   type: RESET_DOCUMENT,
 });
 
-export const importDocument = manifest => ({
+export const importDocument = (manifest, source) => ({
   type: IMPORT_DOCUMENT,
   manifest,
+  source,
 });
 
 export const exportDocument = () => ({

--- a/src/actions/viewState.js
+++ b/src/actions/viewState.js
@@ -25,6 +25,7 @@ import {
   CANCEL_PROJECT_METADATA_EDITS,
   SAVE_PROJECT_METADATA,
   FINISHED_PLAYING,
+  LOAD_SOURCE,
 } from '../constants/viewState';
 import invariant from '../utils/invariant';
 
@@ -108,6 +109,11 @@ export const setCurrentTime = time => ({
 export const loadViewState = state => ({
   type: LOAD_VIEW_STATE,
   state,
+});
+
+export const loadSource = source => ({
+  type: LOAD_SOURCE,
+  payload: { source },
 });
 
 export const editMetadata = rangeId => ({

--- a/src/components/AudioImporter/AudioImporter.js
+++ b/src/components/AudioImporter/AudioImporter.js
@@ -32,10 +32,10 @@ class AudioImporter extends Component {
 
   onImportResource = () => {
     const { onImport } = this.props;
-    console.log(this.importUrlField.value);
-    importResource(this.importUrlField.value)
+    const resourceUri = this.importUrlField.value;
+    importResource(resourceUri)
       .then(manifest => {
-        onImport(manifest);
+        onImport(manifest, resourceUri);
       })
       .catch(error => this.setState({ error }));
   };

--- a/src/constants/viewState.js
+++ b/src/constants/viewState.js
@@ -10,6 +10,7 @@ export const VIEWSTATE = {
   METADATA_TO_EDIT: 'metadataToEdit',
   PROJECT_METADATA_EDITOR_OPEN: 'projectMetadataEditorOpen',
   VERIFY_DIALOG: 'verifyDialog',
+  SOURCE: 'source',
 };
 
 export const DEFAULT_VIEWSTATE_STATE = {
@@ -23,6 +24,7 @@ export const DEFAULT_VIEWSTATE_STATE = {
   [VIEWSTATE.VOLUME]: 70,
   [VIEWSTATE.METADATA_TO_EDIT]: null,
   [VIEWSTATE.PROJECT_METADATA_EDITOR_OPEN]: false,
+  [VIEWSTATE.SOURCE]: null,
   [VIEWSTATE.VERIFY_DIALOG]: {
     open: false,
     title: '',
@@ -46,6 +48,7 @@ export const FAST_REWARD = 'FAST_REWARD';
 export const SET_VOLUME = 'SET_VOLUME';
 export const SET_CURRENT_TIME = 'SET_CURRENT_TIME';
 export const LOAD_VIEW_STATE = 'LOAD_VIEW_STATE';
+export const LOAD_SOURCE = 'LOAD_SOURCE';
 export const EDIT_METADATA = 'EDIT_METATADA';
 export const SET_VERIFY_DIALOG = 'SET_VERIFY_DIALOG';
 export const OPEN_CONFIRM_DIALOG = 'OPEN_CONFIRM_DIALOG';

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,14 @@ import React from 'react';
 import { render } from 'react-dom';
 import Root from './containers/Root/Root';
 import configureStore from './store/main';
+import * as qs from 'query-string';
 
-const { store, persistor } = configureStore();
+const { resource, fresh, ...hash } = qs.parse(location.hash);
+
+// Set the hash back
+location.hash = qs.stringify({ resource, ...hash });
+
+const { store, persistor } = configureStore(resource, fresh);
 
 render(
   <Root store={store} persistor={persistor} />,

--- a/src/reducers/viewState.js
+++ b/src/reducers/viewState.js
@@ -28,6 +28,7 @@ import {
   CANCEL_PROJECT_METADATA_EDITS,
   SAVE_PROJECT_METADATA,
   FINISHED_PLAYING,
+  LOAD_SOURCE,
 } from '../constants/viewState';
 
 import { AUDIO_LOADING } from '../constants/canvas';
@@ -130,6 +131,12 @@ const viewState = (state = DEFAULT_VIEWSTATE_STATE, action) => {
     case LOAD_VIEW_STATE:
       return update(DEFAULT_VIEWSTATE_STATE, {
         $merge: action.state,
+      });
+    case LOAD_SOURCE:
+      return update(state, {
+        [VIEWSTATE.SOURCE]: {
+          $set: action.payload.source,
+        },
       });
     case EDIT_METADATA:
       return update(state, {

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -22,6 +22,7 @@ import {
   play,
   pause,
   cancelProjectMetadataEdits,
+  loadSource,
 } from '../actions/viewState';
 import {
   NEXT_BUBBLE,
@@ -74,22 +75,29 @@ const getPreviousBubbleStartTime = state => {
 const getSelectedBubbles = state =>
   Object.values(state.range)
     .filter(bubble => bubble.isSelected)
-    .sort(
-      (bubbleA, bubbleB) =>
-        bubbleA[RANGE.START_TIME] === bubbleB[RANGE.START_TIME]
-          ? bubbleA[RANGE.DEPTH] - bubbleB[RANGE.DEPTH]
-          : bubbleA[RANGE.START_TIME] - bubbleB[RANGE.START_TIME]
+    .sort((bubbleA, bubbleB) =>
+      bubbleA[RANGE.START_TIME] === bubbleB[RANGE.START_TIME]
+        ? bubbleA[RANGE.DEPTH] - bubbleB[RANGE.DEPTH]
+        : bubbleA[RANGE.START_TIME] - bubbleB[RANGE.START_TIME]
     );
 
 const getState = state => state;
 
-function* importDocument({ manifest }) {
-  const loadedState = loadProjectState(manifest);
+function* importDocument({ manifest, source }) {
+  const { viewState } = yield select();
+
+  if (viewState.source === source) {
+    return;
+  }
+
+  const loadedState = loadProjectState(manifest, source);
+
   yield put(unloadAudio());
   yield put(loadProject(loadedState.project));
   yield put(loadCanvas(loadedState.canvas));
   yield put(loadRanges(loadedState.range));
   yield put(loadViewState(loadedState.viewState));
+  yield put(loadSource(loadedState.source));
 }
 
 function* saveRange({ payload }) {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -7,29 +7,36 @@ import rootSaga from '../sagas/index';
 import importResource from '../components/AudioImporter/AudioImporter.Utils';
 import { importDocument } from '../actions/project';
 
-const persistConfig = {
-  key: 'timeliner-root',
-  storage,
-};
-
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-const persistedReducer = persistReducer(persistConfig, rootReducer);
-
-export default function configureStore(wAudio) {
+export default function configureStore(wAudio, fresh = false) {
   const sagaMiddleware = createSagaMiddleware();
+  const persistedReducer = persistReducer(
+    {
+      key: 'timeliner-root' + wAudio,
+      storage,
+    },
+    rootReducer
+  );
+
   const store = createStore(
     persistedReducer,
     {},
     composeEnhancers(applyMiddleware(sagaMiddleware))
   );
   const persistor = persistStore(store);
+
+  if (fresh) {
+    persistor.purge();
+  }
+
   store.runSaga = sagaMiddleware.run;
   store.close = () => store.dispatch(END);
   store.runSaga(rootSaga);
+  // @todo move this to saga.
   if (wAudio) {
     importResource(wAudio).then(manifest => {
-      store.dispatch(importDocument(manifest));
+      store.dispatch(importDocument(manifest, wAudio));
     });
   }
   return { store, persistor };

--- a/src/utils/iiifLoader.js
+++ b/src/utils/iiifLoader.js
@@ -201,9 +201,10 @@ const manifestToViewState = manifest => ({
   [VIEWSTATE.IS_SETTINGS_OPEN]: false,
 });
 
-export const loadProjectState = manifest => ({
+export const loadProjectState = (manifest, source) => ({
   project: manifestToProject(manifest),
   canvas: processCanvas(manifest.items[0]),
   range: processStructures(manifest),
   viewState: manifestToViewState(manifest),
+  source,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -13018,6 +13018,14 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -14957,6 +14965,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Allows for urls to be built using `#resource=https://..` where resource is either a URL for an MP3 or audio source. Also caches per URL, and supports adding `&fresh=true` to nuke the internal cache.

Closes #180
Closes #181