### PR TITLE
Fixed SVG title attribute

### DIFF
--- a/src/components/BubbleDisplay/BubbleDisplay.js
+++ b/src/components/BubbleDisplay/BubbleDisplay.js
@@ -102,6 +102,7 @@ class BubbleDisplay extends Component {
       colour: point.colour || colours[(point.depth - 1) % colours.length],
       height: point.depth * bubbleHeight,
       label: point.label,
+      summary: point.summary,
       dX: this.getDx(point, pts, projectionFactor),
       point,
       isSelected: point.isSelected,

--- a/src/components/SingleBubble/SingleBubble.js
+++ b/src/components/SingleBubble/SingleBubble.js
@@ -149,9 +149,7 @@ class SingleBubble extends Component {
           strokeWidth={isSelected ? 4 : 0}
           stroke={isSelected ? 'black' : 'transparent'}
         >
-          <title>
-            {label} - {summary}
-          </title>
+          <title>{label}</title>
         </path>
         <text
           textAnchor="middle"

--- a/src/components/SingleBubble/SingleBubble.js
+++ b/src/components/SingleBubble/SingleBubble.js
@@ -52,6 +52,8 @@ class SingleBubble extends Component {
     onClick: PropTypes.func,
     /** Label for the bubble */
     label: PropTypes.string,
+    /** Summary for the bubble */
+    summary: PropTypes.string,
     /** Bubble style */
     shape: PropTypes.string,
     /** is bubble selected */
@@ -112,12 +114,12 @@ class SingleBubble extends Component {
 
   render() {
     const {
-      onClick,
       height,
       width,
       dX,
       colour,
       label,
+      summary,
       labelColour,
       shape,
       isSelected,
@@ -146,8 +148,11 @@ class SingleBubble extends Component {
           fill={colour}
           strokeWidth={isSelected ? 4 : 0}
           stroke={isSelected ? 'black' : 'transparent'}
-          title={label}
-        />
+        >
+          <title>
+            {label} - {summary}
+          </title>
+        </path>
         <text
           textAnchor="middle"
           fill={labelColour}


### PR DESCRIPTION
Uses the `title` element in SVG, which operates in the same way as the `title=""` element in HTML to show a native tooltip when you hover a bubble and wait a short time.
<img width="271" alt="Screenshot 2019-04-29 at 09 52 58" src="https://user-images.githubusercontent.com/8266711/56885608-c1128100-6a64-11e9-865e-943d84602482.png">
